### PR TITLE
Rename Monero class

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,10 +34,10 @@ Start your RPC Client `./monero-wallet-rpc --testnet  --rpc-bind-port 18081 --rp
 ## Getting started
 
 ### Configuration
-    Monero.config.host = "127.0.0.1"
-    Monero.config.port = "18081"
-    Monero.config.username = "username"
-    Monero.config.password = "password"
+    RPC.config.host = "127.0.0.1"
+    RPC.config.port = "18081"
+    RPC.config.username = "username"
+    RPC.config.password = "password"
 
 
 
@@ -50,33 +50,33 @@ ___
 
 Get the current address
 
-    Monero::Wallet.address
+    RPC::Wallet.address
 	=> "9wm6oNA5nP3LnugTKRSwGJhW4vnYv8RAVdRvYyvbistbHUnojyTHyHcYpbZvbTZHDsi4rF1EK5TiYgnCN6FWM9HjTDpKXAE"
 ___
 
 Create a new address for a payment (integrated address)
 
-	Monero::Wallet.make_integrated_address
+	RPC::Wallet.make_integrated_address
 	=> {"integrated_address"=>"A7TmpAyaPeZLnugTKRSwGJhW4vnYv8RAVdRvYyvbistbHUnojyTHyHcYpbZvbTZHDsi4rF1EK5TiYgnCN6FWM9HjfufSYUchQ8hH2R272H",
  	"payment_id"=>"9d985c985ce58a8e"}
 ___
 To get the balance of the current wallet (we use the gem 'money')
 
-    Monero::Wallet.balance
+    RPC::Wallet.balance
     # returns an ::XMR object which is just a shortcut for ::Money(amount, :xmr)
     => #<Money fractional:9980629640000 currency:XMR>
 
-    Monero::Wallet.balance.format
+    RPC::Wallet.balance.format
     => "9.980629640000 XMR"
 
 To get the unlocked balance, which is currently available
 
-    Monero::Wallet.unlocked_balance
+    RPC::Wallet.unlocked_balance
     => #<Money fractional:10000 currency:XMR>
 
 To get both combined
 
-    Monero::Wallet.getbalance
+    RPC::Wallet.getbalance
     => {"balance"=>9961213880000, "unlocked_balance"=>10000}
 
 
@@ -84,16 +84,16 @@ To get both combined
 ___
 To get the current block height
 
-    Monero::Wallet.getheight
+    RPC::Wallet.getheight
     => 1008032
 
 
 ___
 
-Send XMR to an address via `Monero::Transfer.create`. If successfull you will get the transaction  details. If not succesfull you'll get returned nil.
+Send XMR to an address via `RPC::Transfer.create`. If successfull you will get the transaction  details. If not succesfull you'll get returned nil.
 
     amount= 20075 #in atomic units. 1000000000000 == 1.0 XMR    
-    Monero::Transfer.create("A7TmpAyaPeZLnugTKRSwGJhW4vnYv8RAVdRvYyvbistbHUnojyTHyHcYpbZvbTZHDsi4rF1EK5TiYgnCN6FWM9HjfwGRvbCHYCZAaKSzDx", amount)
+    RPC::Transfer.create("A7TmpAyaPeZLnugTKRSwGJhW4vnYv8RAVdRvYyvbistbHUnojyTHyHcYpbZvbTZHDsi4rF1EK5TiYgnCN6FWM9HjfwGRvbCHYCZAaKSzDx", amount)
 	=> {"fee"=>19415760000,
  		"tx_blob"=>"020001020005bbcf0896e3.......
 
@@ -112,7 +112,7 @@ To send payments to multiple recipients simply use an array of `[:recipient, :am
     	{address:A7TmpAyaPeZLnugTKRSwGJhW4vnYv8RAVdRvYyvbistbHUnojyTHyHcYpbZvbTZHDsi4rF1EK5TiYgnCN6FWM9HjfrgPgAEasYGSVhUdwe amount: 442130000}
     ]
 
-    Monero::Transfer.send_bulk(recipients, options)
+    RPC::Transfer.send_bulk(recipients, options)
 
 ___
 

--- a/lib/monero.rb
+++ b/lib/monero.rb
@@ -1,20 +1,16 @@
 require 'money'
-require 'monero/config'
-require 'monero/payment'
-require 'monero/client'
-require 'monero/version'
-require 'monero/wallet'
-require 'monero/transfer'
+require 'rpc/config'
+require 'rpc/payment'
+require 'rpc/client'
+require 'rpc/version'
+require 'rpc/wallet'
+require 'rpc/transfer'
 
-module Monero
+module RPC
   def self.config
-    @@config ||= Monero::Config.instance
+    @@config ||= RPC::Config.instance
   end
 end
-
-# ActiveSupport.on_load(:active_record) do
-#   include Monero::Model
-# end
 
 Money::Currency.register({ :priority            => 1, :iso_code            => "xmr", :iso_numeric         => "846", :name                => "Monero", :symbol              => "XMR", :subunit             => "", :subunit_to_unit     => 1000000000000, :decimal_mark        => ".", :thousands_separator => ""})
 #

--- a/lib/monero/version.rb
+++ b/lib/monero/version.rb
@@ -1,3 +1,0 @@
-module Monero
-  VERSION = "0.0.0.3"
-end

--- a/lib/rpc/client.rb
+++ b/lib/rpc/client.rb
@@ -1,4 +1,4 @@
-module Monero
+module RPC
   class Client
     #class RequestError < StandardError; end
 
@@ -12,12 +12,12 @@ module Monero
 
       args = ""
       args << " -s"
-      args << " -u #{Monero.config.username}:#{Monero.config.password} --digest"
+      args << " -u #{RPC.config.username}:#{RPC.config.password} --digest"
       args << " -X POST #{base_uri}/json_rpc"
       args << " -d '#{data}'"
       args << " -H 'Content-Type: application/json'"
 
-      p "curl #{args}" if Monero.config.debug
+      p "curl #{args}" if RPC.config.debug
 
       json = JSON.parse(`curl #{args}`)
 
@@ -32,7 +32,7 @@ module Monero
     private
 
     def self.base_uri
-      "http://#{Monero.config.host}:#{Monero.config.port}"
+      "http://#{RPC.config.host}:#{RPC.config.port}"
     end
 
   end

--- a/lib/rpc/config.rb
+++ b/lib/rpc/config.rb
@@ -1,5 +1,5 @@
 require 'singleton'
-module Monero
+module RPC
   class Config
     include Singleton
     attr_accessor :host, :port, :username, :password, :debug

--- a/lib/rpc/payment.rb
+++ b/lib/rpc/payment.rb
@@ -1,4 +1,4 @@
-module Monero
+module RPC
 
   class Payment
   end

--- a/lib/rpc/transfer.rb
+++ b/lib/rpc/transfer.rb
@@ -22,7 +22,7 @@
 # get_tx_hex - boolean; Return the transaction as hex string after sending
 
 
-module Monero
+module RPC
   # => {"integrated_address"=>"A7TmpAyaPeZLnugTKRSwGJhW4vnYv8RAVdRvYyvbistbHUnojyTHyHcYpbZvbTZHDsi4rF1EK5TiYgnCN6FWM9HjfwGRvbCHYCZAaKSzDx", "payment_id"=>"c7e7146b3335aa54"}
 
   class Transfer
@@ -48,7 +48,7 @@ module Monero
         payment_id: payment_id, get_tx_key: get_tx_key, priority: priority, do_not_relay: do_not_relay, get_tx_hex: get_tx_hex
       }
 
-      Monero::Client.request("transfer", options)
+      RPC::Client.request("transfer", options)
     end
 
   end

--- a/lib/rpc/version.rb
+++ b/lib/rpc/version.rb
@@ -1,0 +1,3 @@
+module RPC
+  VERSION = "0.0.0.4"
+end

--- a/lib/rpc/wallet.rb
+++ b/lib/rpc/wallet.rb
@@ -1,22 +1,22 @@
-module Monero
+module RPC
 
   class Wallet
 
     def self.create_address(label="")
-      Monero::Client.request("create_address", label: label)
+      RPC::Client.request("create_address", label: label)
     end
 
     def self.get_address
-      Monero::Client.request("get_address")["address"]
+      RPC::Client.request("get_address")["address"]
     end
     def self.address; getaddress; end
 
     def self.get_addresses
-      Monero::Client.request("get_address")["addresses"]
+      RPC::Client.request("get_address")["addresses"]
     end
 
     def self.getbalance
-      Monero::Client.request("getbalance")
+      RPC::Client.request("getbalance")
     end
 
     def self.balance
@@ -28,16 +28,16 @@ module Monero
     end
 
     def self.getaddress
-      Monero::Client.request("getaddress")["address"]
+      RPC::Client.request("getaddress")["address"]
     end
 
     def self.getheight
-      Monero::Client.request("getheight")["height"]
+      RPC::Client.request("getheight")["height"]
     end
 
     def self.query_key(type)
       raise ArgumentError unless ["mnemonic", "view_key"].include?(type.to_s)
-      Monero::Client.request("query_key", {key_type: type})["key"]
+      RPC::Client.request("query_key", {key_type: type})["key"]
     end
     def self.view_key; query_key(:view_key); end
     def self.mnemonic_seed; query_key(:mnemonic); end
@@ -46,19 +46,19 @@ module Monero
     def self.make_integrated_address(payment_id = "")
       # TODO
       # Check if payment_id is correct format
-      Monero::Client.request("make_integrated_address", {payment_id: payment_id})
+      RPC::Client.request("make_integrated_address", {payment_id: payment_id})
     end
 
     def self.incoming_transfers(type)
       raise ArgumentError unless ["all", "available", "unavailable"].include?(type.to_s)
-      json = Monero::Client.request("incoming_transfers", {transfer_type: type})
+      json = RPC::Client.request("incoming_transfers", {transfer_type: type})
       json["transfers"] || []
     end
 
     def self.get_payments(payment_id)
-      payments = Monero::Client.request("get_payments", {payment_id: payment_id})["payments"] || []
+      payments = RPC::Client.request("get_payments", {payment_id: payment_id})["payments"] || []
       # TODO
-      # make it a Monero::Payment that hase a amount as XMR and confirmations (getheight - tx.block_height)
+      # make it a RPC::Payment that hase a amount as XMR and confirmations (getheight - tx.block_height)
       payments.map{|x| Payment.from_raw(x) }
     end
 
@@ -83,11 +83,11 @@ module Monero
 
       options = {in: f_in, out: out, pending: pending, failed: failed, pool: pool, filter_by_height: filter_by_height, min_height: min_height, max_height: max_height}
 
-      Monero::Client.request("get_transfers", options)
+      RPC::Client.request("get_transfers", options)
     end
 
     def self.get_transfer_by_txid(txid)
-      Monero::Client.request("get_transfer_by_txid", {txid: txid })
+      RPC::Client.request("get_transfer_by_txid", {txid: txid })
     end
 
     # creates a wallet and uses it
@@ -96,14 +96,14 @@ module Monero
       # TODO
       # language correct format?
       options = { filename: filename, password: password, language: language }
-      !! Monero::Client.request("create_wallet", options)
+      !! RPC::Client.request("create_wallet", options)
     end
     singleton_class.send(:alias_method, :create, :create_wallet)
 
     # returns current balance if open successfull
     def self.open_wallet(filename, password="")
       options = { filename: filename, password: password}
-      if Monero::Client.request("open_wallet", options)
+      if RPC::Client.request("open_wallet", options)
         balance
       else
         false
@@ -113,7 +113,7 @@ module Monero
 
     # stops current RPC process!
     def self.stop_wallet
-      Monero::Client.close!
+      RPC::Client.close!
     end
     singleton_class.send(:alias_method, :close, :stop_wallet)
 

--- a/monero.gemspec
+++ b/monero.gemspec
@@ -1,11 +1,11 @@
 # coding: utf-8
 lib = File.expand_path('../lib', __FILE__)
 $LOAD_PATH.unshift(lib) unless $LOAD_PATH.include?(lib)
-require 'monero/version'
+require 'rpc/version'
 
 Gem::Specification.new do |spec|
   spec.name          = "monero"
-  spec.version       = Monero::VERSION
+  spec.version       = RPC::VERSION
   spec.authors       = ["Tim Kretschmer"]
   spec.email         = ["tim@krtschmr.de"]
   spec.description   = %q{A Monero-Wallet-RPC ruby client}
@@ -24,5 +24,5 @@ Gem::Specification.new do |spec|
 
   spec.required_rubygems_version = '>= 1.3.6'
 
-  spec.add_dependency "money"  
+  spec.add_dependency "money"
 end


### PR DESCRIPTION
rename Monero class into RPC class to avoid future nameing issues if used along crypto related projects that already use the class Monero