### PR TITLE
Fix error with no constantize method

### DIFF
--- a/lib/monero.rb
+++ b/lib/monero.rb
@@ -1,4 +1,6 @@
 require 'money'
+require 'active_support'
+require 'active_support/core_ext'
 require 'rpc/config'
 require 'rpc/payment'
 require 'rpc/client'

--- a/lib/rpc/version.rb
+++ b/lib/rpc/version.rb
@@ -1,3 +1,3 @@
 module RPC
-  VERSION = "0.0.0.6"
+  VERSION = "0.0.0.7"
 end

--- a/monero.gemspec
+++ b/monero.gemspec
@@ -25,4 +25,5 @@ Gem::Specification.new do |spec|
   spec.required_rubygems_version = '>= 1.3.6'
 
   spec.add_dependency "money"
+  spec.add_dependency "activesupport"
 end


### PR DESCRIPTION
Fixes this error:
```
2.4.1 :091 > RPC::Wallet.get_all_incoming_transfers
NoMethodError: undefined method `constantize' for "RPC::IncomingTransfer":String
```