### PR TITLE
Fix: NoMethodError (undefined method `confirmations=' for #<RPC::IncomingTransfer...

### DIFF
--- a/lib/rpc/incoming_transfer.rb
+++ b/lib/rpc/incoming_transfer.rb
@@ -1,16 +1,12 @@
 module RPC
   class IncomingTransfer
 
-    attr_accessor :address, :amount, :double_spend_seen, :fee, :height, :note, :payment_id, :subaddr_index, :timestamp, :txid, :type, :unlock_time, :destinations
+    attr_accessor :address, :amount, :double_spend_seen, :fee, :height, :note, :payment_id, :subaddr_index, :timestamp, :txid, :type, :unlock_time, :destinations, :confirmations, :suggested_confirmations_threshold
 
     def initialize(args={})
       args.each do |k,v|
         self.send("#{k}=", v)
       end
-    end
-
-    def confirmations
-      pending? ? 0 : RPC::Wallet.getheight - height
     end
 
     def confirmed?

--- a/lib/rpc/version.rb
+++ b/lib/rpc/version.rb
@@ -1,3 +1,3 @@
 module RPC
-  VERSION = "0.0.0.8"
+  VERSION = "0.0.0.9"
 end


### PR DESCRIPTION
Hi, 
I have an update. There was an error caused by 0.13, so the new Monero version. 

The new monero version now includes "confirmations" and "suggested_confirmations_threshold". Both have been added to the module class "IncomingTransfer".

Methods "confirmed?" and "pending?" checked are still working, as they should.
