### PR TITLE
Add RPC::Client.new

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    monero (0.0.0.9)
+    monero (0.0.0.10)
       money
 
 GEM

--- a/lib/rpc/client.rb
+++ b/lib/rpc/client.rb
@@ -1,5 +1,16 @@
 module RPC
   class Client
+    attr_reader :host, :port, :username, :password, :transfer_clazz, :rpc, :debug
+
+    def initialize(host, port, username, password, transfer_clazz, rpc=false, debug=false)
+      @host = host
+      @port = port
+      @username = username
+      @password = password
+      @transfer_clazz = transfer_clazz
+      @rpc = rpc
+      @debug = debug
+    end
 
     def self.close!
       request("stop_wallet")
@@ -10,12 +21,17 @@ module RPC
 
       args = ""
       args << " -s"
-      args << " -u #{RPC.config.username}:#{RPC.config.password} --digest"
-      args << " -X POST #{base_uri}/json_rpc"
+      if (rpc)
+        args << " -u #{RPC.config.username}:#{RPC.config.password} --digest"
+        args << " -X POST #{base_uri}/json_rpc"
+      else
+        args << " -u #{username}:#{password} --digest"
+        args << " -X POST #{uri}/json_rpc"
+      end
       args << " -d '#{data}'"
       args << " -H 'Content-Type: application/json'"
 
-      p "curl #{args}" if RPC.config.debug
+      p "curl #{args}" if debug or RPC.config.debug
 
       json = JSON.parse(`curl #{args}`)
 
@@ -27,10 +43,18 @@ module RPC
       json["result"]
     end
 
+    def rpc
+      @rpc || false
+    end
+
     private
 
     def self.base_uri
       "http://#{RPC.config.host}:#{RPC.config.port}"
+    end
+
+    def self.uri
+      "http://#{host}:#{port}"
     end
 
   end

--- a/lib/rpc/version.rb
+++ b/lib/rpc/version.rb
@@ -1,3 +1,3 @@
 module RPC
-  VERSION = "0.0.0.9"
+  VERSION = "0.0.0.10"
 end

--- a/spec/monero_spec.rb
+++ b/spec/monero_spec.rb
@@ -104,4 +104,26 @@ RSpec.describe RPC do
     expect(transfer['unsigned_txset']).to be_empty
   end
 
+  it "initializes the monero client" do
+    monero_client = RPC::Client.new(
+      "mymonerohost.com",
+      "38083",
+      "username",
+      "password",
+      "MoneroTransfer",
+      true,
+      true
+    )
+
+    expect(monero_client.host).to eq("mymonerohost.com")
+    expect(monero_client.port).to eq("38083")
+    expect(monero_client.username).to eq("username")
+    expect(monero_client.password).to eq("password")
+    expect(monero_client.transfer_clazz).to eq("MoneroTransfer")
+    expect(monero_client.rpc).to eq(true)
+
+    debug = debug or RPC.config.debug
+    expect(monero_client.debug).to be_truthy
+  end
+
 end


### PR DESCRIPTION
## Description
- Add `RPC::Client.new(host, port, username, password, transfer_clazz, rpc, debug)`

## GitHub Issue
#15 

## Pull Request Changes
- Add `attr_reader` to `RPC::Client`
- Add `uri` method to `RPC::Client`