### PR TITLE
Use attr_reader when instantiating client

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    monero (0.0.0.11)
+    monero (0.0.13)
       money
 
 GEM

--- a/lib/monero_rpc/client.rb
+++ b/lib/monero_rpc/client.rb
@@ -2,16 +2,16 @@ class MoneroRPC::Client
   include MoneroRPC::Wallet
   include MoneroRPC::Transfer
 
-  attr_accessor :host, :port, :username, :password, :debug, :in_transfer_clazz, :out_transfer_clazz
+  attr_reader :host, :port, :username, :password, :debug, :in_transfer_clazz, :out_transfer_clazz
 
   def initialize(args= {})
-    self.host     = args.fetch(:host,     MoneroRPC.config.host)
-    self.port     = args.fetch(:port,     MoneroRPC.config.port)
-    self.username = args.fetch(:username, MoneroRPC.config.username)
-    self.password = args.fetch(:password, MoneroRPC.config.password)
-    self.debug    = args.fetch(:debug,    MoneroRPC.config.debug)
-    self.in_transfer_clazz = args.fetch(:in_transfer_clazz, MoneroRPC.config.in_transfer_clazz || "MoneroRPC::IncomingTransfer")
-    self.out_transfer_clazz = args.fetch(:out_transfer_clazz, MoneroRPC.config.out_transfer_clazz || "MoneroRPC::OutgoingTransfer")
+    @host     = args.fetch(:host,     MoneroRPC.config.host)
+    @port     = args.fetch(:port,     MoneroRPC.config.port)
+    @username = args.fetch(:username, MoneroRPC.config.username)
+    @password = args.fetch(:password, MoneroRPC.config.password)
+    @debug    = args.fetch(:debug,    MoneroRPC.config.debug)
+    @in_transfer_clazz = args.fetch(:in_transfer_clazz, MoneroRPC.config.in_transfer_clazz || "MoneroRPC::IncomingTransfer")
+    @out_transfer_clazz = args.fetch(:out_transfer_clazz, MoneroRPC.config.out_transfer_clazz || "MoneroRPC::OutgoingTransfer")
   end
 
   def close!

--- a/lib/monero_rpc/version.rb
+++ b/lib/monero_rpc/version.rb
@@ -1,3 +1,3 @@
 module MoneroRPC
-  VERSION = "0.0.12"
+  VERSION = "0.0.13"
 end

--- a/spec/monero_spec.rb
+++ b/spec/monero_spec.rb
@@ -106,4 +106,11 @@ RSpec.describe MoneroRPC do
     expect(transfer['unsigned_txset']).to be_empty
   end
 
+  it "does not change configuration once instantiated" do
+    expect(monero_rpc).not_to respond_to(:host=)
+    expect(monero_rpc).not_to respond_to(:port=)
+    expect(monero_rpc).not_to respond_to(:username=)
+    expect(monero_rpc).not_to respond_to(:password=)
+  end
+
 end


### PR DESCRIPTION
## Description

Previously, when the `$monero_rpc` is instantiated, you could still change the host (meaning that there is still a possibility of a race condition when instance is used across threads). This fixes it so that once the `$monero_rpc` is instantiated, you cannot change the host, like what #16 was intended to do.

Added a test to check if setter methods cannot be accessed.